### PR TITLE
Hacky fix for building with texinfo >= 6.0

### DIFF
--- a/bfd/doc/Makefile.in
+++ b/bfd/doc/Makefile.in
@@ -385,22 +385,24 @@ distclean-libtool:
 	-rm -f libtool
 
 bfd.info: bfd.texinfo $(bfd_TEXINFOS)
-	restore=: && backupdir="$(am__leading_dot)am$$$$" && \
-	rm -rf $$backupdir && mkdir $$backupdir && \
-	if ($(MAKEINFO) --version) >/dev/null 2>&1; then \
-	  for f in $@ $@-[0-9] $@-[0-9][0-9] $(@:.info=).i[0-9] $(@:.info=).i[0-9][0-9]; do \
-	    if test -f $$f; then mv $$f $$backupdir; restore=mv; else :; fi; \
-	  done; \
-	else :; fi && \
-	if $(MAKEINFO) $(AM_MAKEINFOFLAGS) $(MAKEINFOFLAGS) -I $(srcdir) \
-	 -o $@ `test -f 'bfd.texinfo' || echo '$(srcdir)/'`bfd.texinfo; \
-	then \
-	  rc=0; \
-	else \
-	  rc=$$?; \
-	  $$restore $$backupdir/* `echo "./$@" | sed 's|[^/]*$$||'`; \
-	fi; \
-	rm -rf $$backupdir; exit $$rc
+	# HACK: rebuilding this does not work with texinfo 6.0 and newer
+	@echo Skipping bfd.info
+# 	restore=: && backupdir="$(am__leading_dot)am$$$$" && \
+# 	rm -rf $$backupdir && mkdir $$backupdir && \
+# 	if ($(MAKEINFO) --version) >/dev/null 2>&1; then \
+# 	  for f in $@ $@-[0-9] $@-[0-9][0-9] $(@:.info=).i[0-9] $(@:.info=).i[0-9][0-9]; do \
+# 	    if test -f $$f; then mv $$f $$backupdir; restore=mv; else :; fi; \
+# 	  done; \
+# 	else :; fi && \
+# 	if $(MAKEINFO) $(AM_MAKEINFOFLAGS) $(MAKEINFOFLAGS) -I $(srcdir) \
+# 	 -o $@ `test -f 'bfd.texinfo' || echo '$(srcdir)/'`bfd.texinfo; \
+# 	then \
+# 	  rc=0; \
+# 	else \
+# 	  rc=$$?; \
+# 	  $$restore $$backupdir/* `echo "./$@" | sed 's|[^/]*$$||'`; \
+# 	fi; \
+# 	rm -rf $$backupdir; exit $$rc
 
 bfd.dvi: bfd.texinfo $(bfd_TEXINFOS) 
 	TEXINPUTS="$(am__TEXINFO_TEX_DIR)$(PATH_SEPARATOR)$$TEXINPUTS" \

--- a/ld/Makefile.in
+++ b/ld/Makefile.in
@@ -835,22 +835,24 @@ distclean-libtool:
 	-rm -f libtool
 
 ld.info: ld.texinfo $(ld_TEXINFOS)
-	restore=: && backupdir="$(am__leading_dot)am$$$$" && \
-	rm -rf $$backupdir && mkdir $$backupdir && \
-	if ($(MAKEINFO) --version) >/dev/null 2>&1; then \
-	  for f in $@ $@-[0-9] $@-[0-9][0-9] $(@:.info=).i[0-9] $(@:.info=).i[0-9][0-9]; do \
-	    if test -f $$f; then mv $$f $$backupdir; restore=mv; else :; fi; \
-	  done; \
-	else :; fi && \
-	if $(MAKEINFO) $(AM_MAKEINFOFLAGS) $(MAKEINFOFLAGS) -I $(srcdir) \
-	 -o $@ `test -f 'ld.texinfo' || echo '$(srcdir)/'`ld.texinfo; \
-	then \
-	  rc=0; \
-	else \
-	  rc=$$?; \
-	  $$restore $$backupdir/* `echo "./$@" | sed 's|[^/]*$$||'`; \
-	fi; \
-	rm -rf $$backupdir; exit $$rc
+	# HACK: rebuilding this does not work with texinfo 6.0 and newer
+	@echo Skipping ld.info
+# 	restore=: && backupdir="$(am__leading_dot)am$$$$" && \
+# 	rm -rf $$backupdir && mkdir $$backupdir && \
+# 	if ($(MAKEINFO) --version) >/dev/null 2>&1; then \
+# 	  for f in $@ $@-[0-9] $@-[0-9][0-9] $(@:.info=).i[0-9] $(@:.info=).i[0-9][0-9]; do \
+# 	    if test -f $$f; then mv $$f $$backupdir; restore=mv; else :; fi; \
+# 	  done; \
+# 	else :; fi && \
+# 	if $(MAKEINFO) $(AM_MAKEINFOFLAGS) $(MAKEINFOFLAGS) -I $(srcdir) \
+# 	 -o $@ `test -f 'ld.texinfo' || echo '$(srcdir)/'`ld.texinfo; \
+# 	then \
+# 	  rc=0; \
+# 	else \
+# 	  rc=$$?; \
+# 	  $$restore $$backupdir/* `echo "./$@" | sed 's|[^/]*$$||'`; \
+# 	fi; \
+# 	rm -rf $$backupdir; exit $$rc
 
 ld.dvi: ld.texinfo $(ld_TEXINFOS) 
 	TEXINPUTS="$(am__TEXINFO_TEX_DIR)$(PATH_SEPARATOR)$$TEXINPUTS" \


### PR DESCRIPTION
Disable regenerating ld.info and bfd.info. For some reason the build
system decides that the prebuilt versions in the source tree are not
up to date.
