### PR TITLE
Explicit #error while compiling instead of linker errors

### DIFF
--- a/opcodes/cgen-ops.h
+++ b/opcodes/cgen-ops.h
@@ -26,6 +26,10 @@
 #if defined (__GNUC__) && ! defined (SEMOPS_DEFINE_INLINE)
 #define SEMOPS_DEFINE_INLINE
 #define SEMOPS_INLINE extern inline
+/* Modern compilers default -std=c99 which means extern inline will cause linker errors here */
+#if (__STDC_VERSION__ >= 199901L)
+#error "This file must be compiled with -std=gnu89" otherwise there will be linker errors"
+#endif
 #else
 #define SEMOPS_INLINE
 #endif


### PR DESCRIPTION
Newer GCC versions default to -std=c99 which is not compatible with
the GNU89 extern inline semantics expected by this file.
